### PR TITLE
Minor changes to heart icon

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -98,8 +98,16 @@ button:hover {
   flex-wrap: wrap;
 }
 
+.heart-icon svg {
+  fill: none;
+  stroke: #f44336;
+  stroke-width: 1px;
+  stroke-linejoin: round;
+}
+
 .heart-icon:disabled svg {
-  fill: grey;
+  fill: #f44336;
+  opacity: 0.25;
 }
 
 .favorite-dogs li {


### PR DESCRIPTION
Start with a non-filled heart (just with a colored margin) and after favoriting a dog fill the heart and reduce it's opacity.

When I was checking the app I was a bit confused with what was happening around the favorite functionality, in part due to the heart being red from the start. Maybe i'm biased because of using Instagram and that's why I was confused.

Either way, feel free to discard this if it doesn't make sense.